### PR TITLE
Add more reserved events to the blacklist

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -16,16 +16,30 @@ module.exports = function emitter() {
    */
 
   var events = [
-    'end',
-    'open',
-    'data',
-    'error',
     'close',
-    'online',
+    'data',
+    'end',
+    'error',
+    'incoming::data',
+    'incoming::end',
+    'incoming::error',
+    'incoming::open',
+    'incoming::pong',
+    'joinroom',
+    'leaveallrooms',
+    'leaveroom',
     'offline',
-    'timeout',
+    'online',
+    'open',
+    'outgoing::data',
+    'outgoing::end',
+    'outgoing::open',
+    'outgoing::reconnect',
+    'outgoing::ping',
     'reconnect',
-    'reconnecting'
+    'reconnecting',
+    'roomserror',
+    'timeout'
   ];
 
   // events regex


### PR DESCRIPTION
This will add more reserved events to the blacklist including `incoming::` and `outgoing::` prefixed events and `primus-rooms` events.
