### PR TITLE
Remove not reserved and server events from the blacklist

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -16,25 +16,20 @@ module.exports = function emitter() {
    */
 
   var events = [
-    'log',
-    'end',
-    'pong',
-    'open',
-    'data',
-    'error',
     'close',
-    'online',
+    'data',
+    'end',
+    'error',
+    'joinroom',
+    'leaveallrooms',
+    'leaveroom',
     'offline',
-    'timeout',
-    'initialised',
+    'online',
+    'open',
     'reconnect',
     'reconnecting',
-    'connection',
-    'disconnection',
-    'leaveallrooms',
     'roomserror',
-    'leaveroom',
-    'joinroom'
+    'timeout'
   ];
 
   // events regex


### PR DESCRIPTION
This will remove `connection`, `disconnection`, `initialised`, `log` and `pong` events from the blacklist.

If these events were included in the blacklist to prevent confusion, just close the pull request :)
