### PR TITLE
Do the reserved check on the receiving end of the event

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -70,7 +70,6 @@ module.exports = function emitter() {
    */
 
   Emitter.prototype.send = function send(ev) {
-    if (this.conn.reserved(ev)) return this;
     var args = slice.call(arguments);
     this.conn.write(this.packet(args));
     return this;
@@ -109,6 +108,7 @@ module.exports = function emitter() {
     if (null != packet.id) {
       args.push(this.ack(packet.id));
     }
+    if (this.conn.reserved(args[0])) return this;
     this.conn.emit.apply(this.conn, args);
     return this;
   };


### PR DESCRIPTION
The receiving end on should be validating if they are allowed to emit the event. In the previous senario it would be possible that the server emitted an `reconnect` event and it would trigger on the client as it's not blocked on the server. It would also be impossible to emit an `reconnect` event on the server as that event is client is blocked by the client.

This simple trivial change would fix both cases without requiring a list of ALL events that are used in Primus.
