### PR TITLE
Removed event blacklist

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -37,7 +37,7 @@ module.exports = function emitter() {
 
   Emitter.prototype.bind = function bind() {
     var em = this;
-    this.conn.on('data', function (data) {
+    this.conn.on('data', function ondata(data) {
       em.ondata.call(em, data);
     });
     return this;
@@ -153,7 +153,7 @@ module.exports = function emitter() {
     return this;
   };
 
-  // Expose packets & blacklist
+  // Expose packets
   Emitter.packets = packets;
   
   return Emitter;

--- a/test/test.js
+++ b/test/test.js
@@ -169,23 +169,4 @@ describe('primus-emitter', function () {
     srv.listen();
   });
 
-  /*it('should ignore reserved primus events', function (done) {
-    var events = require('../lib/').Emitter.reservedEvents
-      , len = events.length;
-    srv.listen(function () {
-      primus.on('connection', function (spark) {
-        events.forEach(function (ev) {
-          spark.on(ev, function () {
-            done('Should not');
-          });
-        });
-      });
-      var cl = client(srv, primus);
-      events.forEach(function(ev, i){
-        cl.send(ev, 'hi');
-        if (i === (len-1)) done();
-      });
-    });
-  });*/
-
 });


### PR DESCRIPTION
As discussed on https://github.com/cayasso/primus-emitter/issues/16.
This removes the event blacklist with the aim of moving custom reserved events of a given plugin in the plugin itself.
