### PR TITLE
Drop invalid packets

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -1,6 +1,20 @@
 module.exports = function emitter() {
   'use strict';
 
+  var toString = Object.prototype.toString
+    , slice = Array.prototype.slice;
+
+  /**
+   * Check if the given `value` is an `Array`.
+   *
+   * @param {*} value The value to check
+   * @return {Boolean}
+   */
+
+  var isArray = Array.isArray || function isArray(value) {
+    return '[object Array]' === toString.call(value);
+  };
+
   /**
    * Event packets.
    */
@@ -9,9 +23,6 @@ module.exports = function emitter() {
     EVENT:  0,
     ACK:    1
   };
-
-  // shortcut to slice
-  var slice = [].slice;
 
   /**
    * Initialize a new `Emitter`.
@@ -38,8 +49,8 @@ module.exports = function emitter() {
 
   Emitter.prototype.bind = function bind() {
     var em = this;
-    this.conn.on('data', function ondata(data) {
-      em.ondata.call(em, data);
+    this.conn.on('data', function ondata(packet) {
+      em.ondata.call(em, packet);
     });
     return this;
   };
@@ -53,14 +64,17 @@ module.exports = function emitter() {
    */
 
   Emitter.prototype.ondata = function ondata(packet) {
+    if (!isArray(packet.data) || packet.id && 'number' !== typeof packet.id) {
+      return this;
+    }
     switch (packet.type) {
       case packets.EVENT:
         this.onevent(packet);
         break;
       case packets.ACK:
         this.onack(packet);
-        break;
     }
+    return this;
   };
 
   /**
@@ -89,10 +103,8 @@ module.exports = function emitter() {
     // access last argument to see if it's an ACK callback
     if ('function' === typeof args[args.length - 1]) {
       var id = this.ids++;
-      if (this.acks) {
-        this.acks[id] = args.pop();
-        packet.id = id;
-      }
+      this.acks[id] = args.pop();
+      packet.id = id;
     }
     return packet;
   };
@@ -106,11 +118,9 @@ module.exports = function emitter() {
    */
 
   Emitter.prototype.onevent = function onevent(packet) {
-    var args = packet.data || [];
-    if (packet.id) {
-      args.push(this.ack(packet.id));
-    }
+    var args = packet.data;
     if (this.conn.reserved(args[0])) return this;
+    if (packet.id) args.push(this.ack(packet.id));
     this.conn.emit.apply(this.conn, args);
     return this;
   };
@@ -124,8 +134,8 @@ module.exports = function emitter() {
    */
 
   Emitter.prototype.ack = function ack(id) {
-    var conn = this.conn;
-    var sent = false;
+    var conn = this.conn
+      , sent = false;
     return function () {
       if (sent) return; // prevent double callbacks
       sent = true;
@@ -150,8 +160,6 @@ module.exports = function emitter() {
     if ('function' === typeof ack) {
       ack.apply(this, packet.data);
       delete this.acks[packet.id];
-    } else {
-      console.log('bad ack %s', packet.id);
     }
     return this;
   };


### PR DESCRIPTION
It is currently possible to use invalid packets as an attack vector. For example:

``` js
'use strict';

var Primus = require('primus')
  , primus
  , server;

server = require('http').createServer();

primus = new Primus(server);
primus.use('emitter', 'primus-emitter');

server.listen(3000, function () {
  var socket = new primus.Socket('http://localhost:3000');

  socket.write({
    id: '__defineGetter__',
    data: ['foo'],
    type: 1
  });
});
```

will make the server crash.

The correct way to handle this issue is validating the data packets before emitting the `data` events. This is easy to do in Primus using a [message transformer](https://github.com/primus/primus#transforming-and-intercepting-messages) or a plugin like [`fortress-maximus`](https://github.com/primus/fortress-maximus) but assuming that everyone is validating the incoming packets is wrong because it is not mandatory and invalid packets should not make the server crash anyway.

This patch prevents `primus-emitter` from handling invalid packtes.
